### PR TITLE
DPI-2910 Package flipRevenueMetrics in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipRevenueMetrics";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''Revenue-based analytics for understanding the performance of subscription businesses.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    reshape2
+    flipTables
+    ggplot2
+    scales
+    plyr
+    verbs
+    flipStatistics
+    lubridate
+    flipTime
+    dplyr
+    plotly
+    flipStandardCharts
+    flipFormat
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipRevenueMetrics in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR